### PR TITLE
[Fix bug] creating multiple labels when filtering/sorting.

### DIFF
--- a/src/components/routes/HistoryMatrixView.js
+++ b/src/components/routes/HistoryMatrixView.js
@@ -232,7 +232,8 @@ class HistoryMatrixView extends Component {
                             })
                         }}
                         labelToggle={labelToggle}
-                        xlabel={"commits"}/>
+                        xlabel={"commits"}
+                        ylabel={"test cases"}/>
                         
                 }
                 <div id='toolbox'>

--- a/src/components/routes/TestMatrixView.js
+++ b/src/components/routes/TestMatrixView.js
@@ -90,7 +90,6 @@ class TestMatrixView extends Component {
     }
 
     async updateProjectData() {
-        console.debug(`${API_ROOT}/projects`);
         return await json(`${API_ROOT}/projects`)
             .then(response => {
                 let projects = response.projects.map(project => {

--- a/src/components/routes/TestMatrixView.js
+++ b/src/components/routes/TestMatrixView.js
@@ -90,6 +90,7 @@ class TestMatrixView extends Component {
     }
 
     async updateProjectData() {
+        console.debug(`${API_ROOT}/projects`);
         return await json(`${API_ROOT}/projects`)
             .then(response => {
                 let projects = response.projects.map(project => {
@@ -232,7 +233,8 @@ class TestMatrixView extends Component {
                             })
                         }}
                         labelToggle={labelToggle}
-                        xlabel={"methods"}/>
+                        xlabel={"methods"}
+                        ylabel={"test cases"} />
                 }
 
                 <div id='toolbox'>

--- a/src/components/visualizations/MatrixVisualization.js
+++ b/src/components/visualizations/MatrixVisualization.js
@@ -325,7 +325,6 @@ class MatrixVisualization extends Component {
                 .on('click', this.onTestClick);
 
         // text label for the x axis
-        console.log(svg.select("xlabel"));
         svg.select(".xlabel")
             .attr("x", this.state.width / 2)
             .attr("y", 11)

--- a/src/components/visualizations/MatrixVisualization.js
+++ b/src/components/visualizations/MatrixVisualization.js
@@ -19,6 +19,7 @@ class MatrixVisualization extends Component {
             width: 0,
             height: 0,
             xlabel: props.xlabel,
+            ylabel: props.ylabel,
         }
 
         this.margin = {
@@ -220,14 +221,6 @@ class MatrixVisualization extends Component {
             .style("font-size", "12px")
 
         // Add X and Y axis to the visualization
-
-        // text label for the x axis
-        svg.append("text")
-        .attr("x", this.state.width/2 )
-        .attr("y",  11 )
-        .style("text-anchor", "middle")
-        .text(this.state.xlabel);
-
         select("g.x-axis")
             .attr("transform", `translate(${this.margin.left}, ${this.margin.top})`)
             .call(xAxis);
@@ -331,13 +324,22 @@ class MatrixVisualization extends Component {
                 })
                 .on('click', this.onTestClick);
 
-        svg.append("text")
-                .attr("transform", "rotate(-90)")
-                .attr("y", 1)
-                .attr("x",-this.state.height/2)
-                .attr("dy", "0.7em")
-                .style("text-anchor", "middle")
-                .text("test cases");
+        // text label for the x axis
+        console.log(svg.select("xlabel"));
+        svg.select(".xlabel")
+            .attr("x", this.state.width / 2)
+            .attr("y", 11)
+            .style("text-anchor", "middle")
+            .text(this.state.xlabel);
+
+        // text label for the y axis
+        svg.select(".ylabel")
+            .attr("transform", "rotate(-90)")
+            .attr("y", 1)
+            .attr("x", -this.state.height / 2)
+            .attr("dy", "0.7em")
+            .style("text-anchor", "middle")
+            .text(this.state.ylabel);
     }
 
     createTestMatrixView() {
@@ -350,6 +352,10 @@ class MatrixVisualization extends Component {
         svg.append("g").attr("class", "y-axis");
         svg.append("g").attr("class", "testmatrix");
         svg.append("g").attr("class", "tooltip");
+
+        // Create empty labels, they are updated within the update function.
+        svg.append("text").attr("class", "xlabel");
+        svg.append("text").attr("class", "ylabel");
     }
 
     render() {


### PR DESCRIPTION
Updated how labels are created:
1. Also the y-label for the matrix can now configured
2. Every time when the visualization is updated (when you filter or sort) an additional label is placed at the same location, I moved the creation of the label (without content) to the createTestMatrixView, and the updating the label to the update function.